### PR TITLE
swapping API to return different text pullrequest practice

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start -p ${PORT}"
   },
   "dependencies": {
     "date-fns": "^2.30.0",

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,3 +1,3 @@
 export default function handler(req, res) {
-    res.status(200).json({ text: 'Hello' });
+    res.status(200).json({ text: 'Pull Request 001' });
   }


### PR DESCRIPTION
changed API text output and package.json file. The packagejson file might break the  production bulid on vercel. revert is needed